### PR TITLE
Resolve and reject now return the promise for handy chaining.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,0 +1,10 @@
+# History
+
+## 2.0.0
+
+The `resolve` and `reject` methods now return the promise, for simpler chaining.
+These were previously returning `undefined`.
+
+## 1.0.0
+
+Initial release.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Create a deferred object.
 var deferred = new Deferred();
 ```
 
-The promise managed by the deferred object.
+The promise is managed by the deferred object.
 
 ```javascript
 var promise = deferred.promise;
@@ -43,6 +43,12 @@ Reject `deferred.promise` with an error.
 
 ```javascript
 deferred.reject(new Error('Oh noes!'));
+```
+
+Resolve and reject return the promise for easy chaining, e.g.
+
+```javascript
+deferred.resolve('a-resolution').then(/* ... */);
 ```
 
 If you prefer to avoid constructors, you can!

--- a/index.js
+++ b/index.js
@@ -1,12 +1,19 @@
 export default function Deferred() {
-  if (!(this instanceof Deferred)) {
+  var deferred = this;
+
+  if (!(deferred instanceof Deferred)) {
     return new Deferred();
   }
 
-  var deferred = this;
+  deferred.promise = new Promise(function (resolve, reject) {
+    deferred.resolve = function (value) {
+        resolve(value);
+        return deferred.promise;
+    };
 
-  this.promise = new Promise(function (resolve, reject) {
-    deferred.resolve = resolve;
-    deferred.reject = reject;
+    deferred.reject = function (error) {
+        reject(error);
+        return deferred.promise;
+    };
   });
 }

--- a/test.js
+++ b/test.js
@@ -32,7 +32,7 @@ test('instances have a reject property, which is a method', t => {
 });
 
 test('the promise property is resolved with a value when the resolve property is called with that value', t => {
-  var deferred = new Deferred();
+  const deferred = new Deferred();
 
   deferred.resolve('resolution-value');
 
@@ -44,8 +44,15 @@ test('the promise property is resolved with a value when the resolve property is
     .catch(err => t.end(err));
 });
 
+test('resolve returns the promise', t => {
+  const deferred = new Deferred();
+
+  t.equals(deferred.resolve('resolution-value'), deferred.promise);
+  t.end();
+});
+
 test('the promise property is rejected with a value when the reject property is called with that value', t => {
-  var deferred = new Deferred();
+  const deferred = new Deferred();
 
   deferred.reject('rejection-value');
 
@@ -57,4 +64,11 @@ test('the promise property is rejected with a value when the reject property is 
         t.end();
       }
     );
+});
+
+test('reject returns the promise', t => {
+  const deferred = new Deferred();
+
+  t.equals(deferred.reject('rejection-value'), deferred.promise);
+  t.end();
 });


### PR DESCRIPTION
I'll give this a major version bump when merged (in case anyone is relying on these methods returning `undefined`)
